### PR TITLE
Optimized Vandermonde matrix generation for better performance

### DIFF
--- a/src/higham.jl
+++ b/src/higham.jl
@@ -261,9 +261,14 @@ function vand{T}(p::Vector{T}, n::Int)
     # n: number of rows
     # p: a vector
     m = length(p)
-    V = ones(T, m, n)
-    for i = 1:n
-        V[:,i] = p.^(i-1)
+    V = Array(T, m, n)
+    for j = 1:m
+        @inbounds V[j, 1] = 1
+    end
+    for i = 2:n
+        for j = 1:m
+            @inbounds V[j,i] = p[j] * V[j,i-1]
+        end
     end
     return V
 end


### PR DESCRIPTION
This performance patch addresses https://github.com/weijianzhang/MatrixDepot.jl/issues/2. Thanks to @stevengj for suggesting this version of the implementation based on discussions on Julia-User surrounding the following IJulia notebook:

http://nbviewer.ipython.org/gist/synapticarbors/26910166ab775c04c47b