### PR TITLE
updated Project.toml and ci.yml

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.6'
+          - 'lts'
           - '1'
           - 'nightly'
         os:
@@ -23,10 +23,10 @@ jobs:
           - macos-latest
           - windows-latest
         arch:
-          - x64
+          - default
     steps:
       - uses: actions/checkout@v6
-      - uses: julia-actions/setup-julia@v2
+      - uses: julia-actions/setup-julia@v3
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
@@ -51,7 +51,7 @@ jobs:
 #     runs-on: ubuntu-latest
 #     steps:
 #       - uses: actions/checkout@v6
-#       - uses: julia-actions/setup-julia@v2
+#       - uses: julia-actions/setup-julia@v3
 #         with:
 #           version: '1'
 #       - run: |

--- a/Project.toml
+++ b/Project.toml
@@ -17,7 +17,7 @@ SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 ChannelBuffers = "0.3.1, 0.4"
 DataFrames = "0.20 - 0.22, 1"
 JLD2 = "0.5 - 0.6"
-MAT = "0.7 - 0.11"
+MAT = "0.7 - 0.12"
 Scratch = "1"
 julia = "1"
 


### PR DESCRIPTION
use default architecture in CI.yml and use release label 'lts' instead of '1.6'
allow MAT release 0.12 in Project.toml