### PR TITLE
breaking release v1.1

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "MatrixDepot"
 uuid = "b51810bb-c9f3-55da-ae3c-350fc1fbce05"
-version = "1.0.18"
+version = "1.1"
 
 [deps]
 ChannelBuffers = "79a69506-cdd1-4876-b8e5-7af85e53af4f"


### PR DESCRIPTION
Release MatrixDepot v1.1
Required julia versions >= v1.6

That can only be achieved by a breaking release (not v1.0.18, which couldn't be registered)